### PR TITLE
Изменение селектора

### DIFF
--- a/index.css
+++ b/index.css
@@ -80,7 +80,7 @@ p {
   Внешний отступ вниз для параграфа без атрибута class,
   который расположен не последним среди своих соседних элементов
  */
-p:where(:not([class]):not(:last-child)) {
+:where(p:not([class]):not(:last-child)) {
   margin-bottom: var(--paragraphMarginBottom);
 }
 


### PR DESCRIPTION
Предыдущий селектор не работает так как надо из-за особенности псевдокласса :where(), из-за этого у последних тегов p без атрибута класса всё равно применялись внешние отступы снизу