### PR TITLE
refactor: merge duplicate html selectors into a single block

### DIFF
--- a/normalize.css
+++ b/normalize.css
@@ -115,12 +115,9 @@ html {
     при появлении / исчезновении скроллбара
    */
   scrollbar-gutter: stable;
-}
-
-/**
-  Плавный скролл
- */
-html {
+  /**
+    Плавный скролл
+   */
   scroll-behavior: smooth;
 }
 


### PR DESCRIPTION
Combined duplicate `html` selectors into a single block to reduce code duplication.  
No changes to functionality — just a minor cleanup for improved readability.